### PR TITLE
asusctl: remove supergfxctl from optdepends

### DIFF
--- a/asusctl/PKGBUILD
+++ b/asusctl/PKGBUILD
@@ -62,7 +62,6 @@ package_asusctl() {
     'acpi_call: fan control'
     'asusctltray: tray profile switcher'
     'rog-control-center: app to control asusctl'
-    'supergfxctl: hybrid GPU control'
   )
 
   cd "${pkgbase}"


### PR DESCRIPTION
Asusctl 6.3.9 got rid of its uses of supergfxctl.