### PR TITLE
Add kio-snapshot

### DIFF
--- a/kio-snapshot/.SRCINFO
+++ b/kio-snapshot/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = kio-snapshot
+	pkgdesc = Integration of Btrfs filesystem snapshots for KDE applications
+	pkgver = 1.0.0
+	pkgrel = 1
+	url = https://invent.kde.org/system/kio-snapshot
+	arch = x86_64
+	license = LGPL-2.0-or-later
+	makedepends = cmake
+	makedepends = extra-cmake-modules
+	makedepends = qt6-base
+	depends = btrfs-progs
+	depends = kio
+	source = https://invent.kde.org/system/kio-snapshot/-/archive/v1.0.0/kio-snapshot-v1.0.0.tar.gz
+	sha256sums = 56b908d20ba1c866d266c03a4fbe779448ee4e7d0ae6a5389b7043fe97317746
+
+pkgname = kio-snapshot

--- a/kio-snapshot/PKGBUILD
+++ b/kio-snapshot/PKGBUILD
@@ -1,0 +1,22 @@
+pkgname=kio-snapshot
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Integration of Btrfs filesystem snapshots for KDE applications'
+arch=('x86_64')
+url='https://invent.kde.org/system/kio-snapshot'
+license=('LGPL-2.0-or-later')
+depends=('btrfs-progs' 'kio')
+makedepends=('cmake' 'extra-cmake-modules' 'qt6-base')
+source=("$url/-/archive/v$pkgver/$pkgname-v$pkgver.tar.gz")
+sha256sums=('56b908d20ba1c866d266c03a4fbe779448ee4e7d0ae6a5389b7043fe97317746')
+
+build() {
+  cmake -B build -S "$pkgname-v$pkgver" \
+    -DCMAKE_BUILD_TYPE=None \
+    -DCMAKE_INSTALL_PREFIX=/usr
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+}


### PR DESCRIPTION
KIO Snapshot integrates snapper snapshots into KDE Plasma allowing to browse and read snapshots via a snapshot:/ URL in any KIO enabled application (i.e. Dolphin)