### PR TITLE
uxplay: Add at 1.73.6.

### DIFF
--- a/uxplay/.SRCINFO
+++ b/uxplay/.SRCINFO
@@ -1,0 +1,24 @@
+pkgbase = uxplay
+	pkgdesc = AirPlay Unix mirroring server
+	pkgver = 1.73.6
+	pkgrel = 1
+	epoch = 1
+	url = https://github.com/FDH2/UxPlay
+	arch = x86_64
+	arch = aarch64
+	license = GPL-3.0-or-later
+	makedepends = cmake
+	depends = openssl
+	depends = libplist
+	depends = avahi
+	depends = gst-plugins-base
+	depends = gst-plugins-good
+	depends = gst-plugins-bad
+	depends = gst-libav
+	optdepends = gstreamer-vaapi: GStreamer plugin required for certain GPUs
+	source = UxPlay-1.73.6.tar.gz::https://github.com/FDH2/UxPlay/archive/refs/tags/v1.73.6.tar.gz
+	source = uxplay.desktop
+	sha256sums = 3a1a754bc7ed4b0f72b6237aa4d769238b9c20a71b651bc3fe9ac679e2a67f18
+	sha256sums = 6b43385942508d8c360e8360be52719cbf3899868f3560b245731d866fb245a3
+
+pkgname = uxplay

--- a/uxplay/.nvchecker.toml
+++ b/uxplay/.nvchecker.toml
@@ -1,0 +1,4 @@
+[uxplay]
+source = "git"
+git = "https://github.com/FDH2/UxPlay"
+prefix = "v"

--- a/uxplay/PKGBUILD
+++ b/uxplay/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Nico <d3sox at protonmail dot com>
+# Contributor: NelloKudo <marshnelloosu@gmail.com>
+pkgname=uxplay
+_gitname=UxPlay
+pkgver=1.73.6
+epoch=1
+pkgrel=1
+pkgdesc="AirPlay Unix mirroring server"
+arch=('x86_64' 'aarch64')
+url="https://github.com/FDH2/$_gitname"
+license=('GPL-3.0-or-later')
+depends=('openssl' 'libplist' 'avahi' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-libav')
+optdepends=('gstreamer-vaapi: GStreamer plugin required for certain GPUs')
+makedepends=('cmake')
+source=("$_gitname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz" "uxplay.desktop")
+sha256sums=('3a1a754bc7ed4b0f72b6237aa4d769238b9c20a71b651bc3fe9ac679e2a67f18'
+            '6b43385942508d8c360e8360be52719cbf3899868f3560b245731d866fb245a3')
+
+build() {
+  cd "$srcdir/$_gitname-$pkgver"
+  mkdir -p build
+  cd build
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DZOOMFIX=1
+  cmake --build . --config Release
+}
+
+package() {
+  # install binary
+  install -Dm 755 "$srcdir/$_gitname-$pkgver/build/uxplay" "$pkgdir/usr/bin/uxplay"
+  # install desktop file
+  install -Dm 644 "$srcdir/uxplay.desktop" "$pkgdir/usr/share/applications/uxplay.desktop"
+
+  printf "%b" "\e[1;33m==> WARNING: \e[0mIn order for UxPlay to work, the avahi systemd service has to be running. Enable it with: systemctl enable --now avahi-daemon\n"
+  # install manpage
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/uxplay.1" "$pkgdir/usr/share/man/man1/uxplay.1"
+  # install doc
+  install -d "$pkgdir/usr/share/doc/uxplay"
+  install -Dm 644 "$srcdir/$_gitname-$pkgver"/README.* "$pkgdir/usr/share/doc/uxplay"
+  # install license
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/uxplay/LICENSE"
+
+  # install systemd service
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/uxplay.service" "$pkgdir/usr/lib/systemd/user/uxplay.service"
+
+  # install BlueToothLE beacon script
+  install -Dm 755 "$srcdir/$_gitname-$pkgver/Bluetooth_LE_beacon/uxplay-beacon.py" "$pkgdir/usr/bin/uxplay-beacon.py"
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/Bluetooth_LE_beacon/uxplay_beacon_module_BlueZ.py" "$pkgdir/usr/bin/uxplay_beacon_module_BlueZ.py"
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/Bluetooth_LE_beacon/uxplay_beacon_module_BleuIO.py" "$pkgdir/usr/bin/uxplay_beacon_module_BleuIO.py"
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/Bluetooth_LE_beacon/uxplay_beacon_module_HCI.py" "$pkgdir/usr/bin/uxplay_beacon_module_HCI.py"
+  # install beacon script manpage
+  install -Dm 644 "$srcdir/$_gitname-$pkgver/Bluetooth_LE_beacon/uxplay-beacon.1" "$pkgdir/usr/share/man/man1/uxplay-beacon.1"
+}

--- a/uxplay/uxplay.desktop
+++ b/uxplay/uxplay.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=UxPlay
+GenericName=AirPlay server
+Exec=/usr/bin/uxplay
+Icon=computer-apple-ipad-symbolic
+Terminal=true
+Categories=AudioVideo;
+Comment=AirPlay Unix mirroring server


### PR DESCRIPTION
Adding an open source AirServer implementation that allows casting iPad/iPhone screens to Linux 🎉 

Two changes I made to the AUR pkgbuild (https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=uxplay):
- Replaced `arch=('any')` with the actual correct architectures
- Added `-DCMAKE_BUILD_TYPE=Release` to the cmake configure line