### PR TITLE
krefresh: add Windows-style refresh package

### DIFF
--- a/krefresh/PKGBUILD
+++ b/krefresh/PKGBUILD
@@ -1,0 +1,29 @@
+# Contributor: Dharmik Lathiya <dharmiklathiya.it@gmail.com>
+
+pkgname='krefresh'
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Windows-style refresh for KDE Plasma: reload desktop, Dolphin windows and thumbnail caches'
+arch=('any')
+license=('GPL-3.0-or-later')
+depends=(
+  'bash'
+  'coreutils'
+  'dolphin'
+  'kconfig'
+  'plasma-workspace'
+  'qt6-tools'
+  'systemd'
+)
+source=('krefresh'
+        'krefresh.desktop'
+        'krefresh-command.desktop')
+sha512sums=('SKIP'
+            'SKIP'
+            'SKIP')
+
+package() {
+    install -Dm755 "$srcdir/krefresh" "$pkgdir/usr/bin/krefresh"
+    install -Dm644 "$srcdir/krefresh.desktop" "$pkgdir/usr/share/kio/servicemenus/krefresh.desktop"
+    install -Dm644 "$srcdir/krefresh-command.desktop" "$pkgdir/usr/share/applications/krefresh-command.desktop"
+}

--- a/krefresh/krefresh
+++ b/krefresh/krefresh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# krefresh — Windows-style refresh for KDE Plasma
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -euo pipefail
+
+PLASMA_SERVICE="plasma-plasmashell.service"
+
+usage() {
+    cat <<'EOF'
+Usage: krefresh [COMMAND]
+
+Commands:
+  desktop            Reload the Plasma desktop and panels
+  dolphin            Reload all open Dolphin windows
+  icons              Clear thumbnail caches
+  all                Run desktop, dolphin and icons in sequence
+  --setup-shortcut   Bind Meta+R to "krefresh all" (idempotent)
+  -h, --help         Show this help
+
+Examples:
+  krefresh all
+EOF
+}
+
+refresh_desktop() {
+    if systemctl --user is-active "$PLASMA_SERVICE" >/dev/null 2>&1; then
+        systemctl --user restart "$PLASMA_SERVICE"
+        echo "Desktop refreshed."
+    else
+        echo "Plasma shell is not running; nothing to refresh."
+    fi
+}
+
+refresh_dolphin() {
+    if ! command -v qdbus6 >/dev/null 2>&1; then
+        echo "Error: qdbus6 not found (install qt6-tools)." >&2
+        exit 1
+    fi
+    local services found=0
+    services=$(qdbus6 2>/dev/null | grep '^ org\.kde\.dolphin-' | awk '{print $1}') || true
+    for service in $services; do
+        if qdbus6 "$service" /dolphin/Dolphin_1 \
+            org.kde.KMainWindow.activateAction view_redisplay >/dev/null 2>&1; then
+            found=1
+        fi
+    done
+    if [[ $found -eq 0 ]]; then
+        echo "No open Dolphin windows to refresh."
+    else
+        echo "Dolphin refreshed."
+    fi
+}
+
+refresh_icons() {
+    local cache="${XDG_CACHE_HOME:-$HOME/.cache}/thumbnails"
+    if [[ -d "$cache" ]]; then
+        rm -rf "$cache"/*
+        echo "Thumbnail cache cleared."
+    else
+        echo "No thumbnail cache found."
+    fi
+}
+
+setup_shortcut() {
+    if ! command -v kwriteconfig6 >/dev/null 2>&1; then
+        echo "Error: kwriteconfig6 not found (install kconfig)." >&2
+        exit 1
+    fi
+    kwriteconfig6 --file kglobalshortcutsrc \
+        --group krefresh-command.desktop --key _k_friendly_name "krefresh"
+    kwriteconfig6 --file kglobalshortcutsrc \
+        --group krefresh-command.desktop \
+        --key _launch "Meta+R,None,Meta+R,krefresh all"
+    echo "Shortcut installed: Meta+R -> krefresh all"
+    echo "It becomes active on next login (or restart kglobalaccel)."
+}
+
+case "${1:-}" in
+    desktop)          refresh_desktop ;;
+    dolphin)          refresh_dolphin ;;
+    icons)            refresh_icons ;;
+    all)              refresh_desktop; refresh_dolphin; refresh_icons ;;
+    --setup-shortcut) setup_shortcut ;;
+    -h|--help)        usage ;;
+    *)
+        echo "Error: unknown command '${1:-}'" >&2
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/krefresh/krefresh-command.desktop
+++ b/krefresh/krefresh-command.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Exec=krefresh all
+Name=krefresh
+NoDisplay=true
+StartupNotify=false
+Type=Application
+X-KDE-GlobalAccel-CommandShortcut=true

--- a/krefresh/krefresh.desktop
+++ b/krefresh/krefresh.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Service
+X-KDE-ServiceTypes=KonqPopupMenu/Plugin
+X-KDE-Priority=TopLevel
+MimeType=inode/directory;
+Actions=RefreshFolder;
+
+[Desktop Action RefreshFolder]
+Exec=krefresh dolphin
+Icon=view-refresh
+
+Name=Refresh Folder


### PR DESCRIPTION
Adds a new krefresh package for KDE Plasma:

- CLI: desktop (plasmashell reload), dolphin (D-Bus view_redisplay), icons (thumbnail cache), all
- Dolphin service menu 'Refresh Folder'
- Meta+R global shortcut via KGlobalAccel (--setup-shortcut)

Based on cachyos-refresh PR #1685 by Dharmik-Lathiya