### PR TITLE
heroic-games-launcher: Add version of Heroic using system electron

### DIFF
--- a/heroic-games-launcher/.SRCINFO
+++ b/heroic-games-launcher/.SRCINFO
@@ -1,0 +1,32 @@
+pkgbase = heroic-games-launcher
+	pkgdesc = An Open Source Launcher for GOG, Epic Games and Amazon Games
+	pkgver = 2.22.1
+	pkgrel = 1
+	url = https://heroicgameslauncher.com/
+	arch = x86_64
+	license = GPL-3.0-only
+	makedepends = desktop-file-utils
+	makedepends = git
+	makedepends = nodejs
+	makedepends = pnpm
+	depends = which
+	depends = electron43
+	depends = hicolor-icon-theme
+	depends = sh
+	depends = python
+	depends = libgcc
+	depends = glibc
+	depends = zlib-ng-compat
+	optdepends = gamemode
+	optdepends = gamescope
+	optdepends = mangohud
+	source = heroic-games-launcher::git+https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git#tag=v2.22.1
+	source = heroic-games-launcher-5818.patch::https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5818.patch
+	source = heroic-games-launcher-5877.patch::https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5877.patch
+	source = heroic.sh
+	sha256sums = cabb6f90e46f34f4af7388e3ab7c40ddd3502cda73fbeb145d40080d8f76d995
+	sha256sums = 6659c5b2ccd503fd02417ca81a87fb062477cd8cde7fb270e7c05131d9bf3b6e
+	sha256sums = fadb28b05ce74b0af7d709e5b728c6aeab6cd937b80a9f86dbf065e6d83a4022
+	sha256sums = df5fb2b5afc70f46a63913846c4f5d55372584a1468173833fe5106db2303c07
+
+pkgname = heroic-games-launcher

--- a/heroic-games-launcher/.gitignore
+++ b/heroic-games-launcher/.gitignore
@@ -1,0 +1,6 @@
+*
+!.gitignore
+!PKGBUILD
+!.SRCINFO
+!.nvchecker.toml
+!heroic.sh

--- a/heroic-games-launcher/.nvchecker.toml
+++ b/heroic-games-launcher/.nvchecker.toml
@@ -1,0 +1,4 @@
+[heroic-games-launcher]
+source = "git"
+git = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git"
+prefix = "v"

--- a/heroic-games-launcher/PKGBUILD
+++ b/heroic-games-launcher/PKGBUILD
@@ -1,0 +1,82 @@
+# Adapted from `heroic-games-launcher` PKGBUILD at <https://aur.archlinux.org/pkgbase/heroic-games-launcher/>, originally maintained by Fabio 'Lolix' Loli <fabio.loli@disroot.org> -> https://github.com/FabioLolix
+
+_electron=electron43
+pkgver=2.22.1
+
+pkgname=heroic-games-launcher
+pkgrel=1
+pkgdesc="An Open Source Launcher for GOG, Epic Games and Amazon Games"
+arch=(x86_64)
+url=https://heroicgameslauncher.com/
+license=("GPL-3.0-only")
+depends=(
+    "which"
+    "$_electron"
+    # Required for /usr/share/icons/hicolor/ to be respected
+    "hicolor-icon-theme"
+    # Required for the wrapper script
+    "sh"
+
+    # Required by some helper binaries
+    "python"
+    "libgcc"
+    "glibc"
+    "zlib-ng-compat"
+)
+makedepends=(
+    "desktop-file-utils"
+    "git"
+    "nodejs"
+    "pnpm"
+)
+optdepends=(
+    "gamemode"
+    "gamescope"
+    "mangohud"
+)
+source=(
+    "${pkgname}::git+https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git#tag=v${pkgver}"
+    "${pkgname}-5818.patch::https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5818.patch"
+    "${pkgname}-5877.patch::https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5877.patch"
+    "heroic.sh"
+)
+sha256sums=(
+    'cabb6f90e46f34f4af7388e3ab7c40ddd3502cda73fbeb145d40080d8f76d995'
+    '6659c5b2ccd503fd02417ca81a87fb062477cd8cde7fb270e7c05131d9bf3b6e'
+    'fadb28b05ce74b0af7d709e5b728c6aeab6cd937b80a9f86dbf065e6d83a4022'
+    'df5fb2b5afc70f46a63913846c4f5d55372584a1468173833fe5106db2303c07'
+)
+
+prepare() {
+    sed -i "s|@ELECTRON@|${_electron}|" heroic.sh
+
+    cd "${pkgname}"
+    # Required for Heroic to correctly generate Steam shortcuts (pointing to the `/usr/bin/heroic` wrapper script)
+    # Included in Heroic's main branch, can be dropped once 2.23 releases
+    git apply "${srcdir}/${pkgname}-5818.patch"
+    # Required for Epic games with third-party launchers to work with umu
+    # Also already on main
+    git apply "${srcdir}/${pkgname}-5877.patch"
+}
+
+build() {
+    cd "${pkgname}"
+    pnpm install --ignore-scripts
+    pnpm run download-helper-binaries
+    pnpm run dist:linux --dir --x64 -c.electronDist=/usr/lib/$_electron/ -c.electronVersion=$(cat /usr/lib/$_electron/version)
+}
+
+package() {
+    install -Dm755 "${srcdir}/heroic.sh" "${pkgdir}/usr/bin/heroic"
+
+    cd "${pkgname}"
+    mkdir -p "$pkgdir/usr/lib/$pkgname"
+    cp -r dist/linux-unpacked/resources/app.asar{,.unpacked} "${pkgdir}/usr/lib/$pkgname/"
+
+    install -Dm644 flatpak/com.heroicgameslauncher.hgl.png -t "${pkgdir}/usr/share/icons/hicolor/128x128/apps"
+    install -Dm644 src/frontend/assets/heroic-icon.svg "${pkgdir}/usr/share/icons/hicolor/scalable/com.heroicgameslauncher.hgl.svg"
+    install -Dm644 COPYING -t "$pkgdir/usr/share/licenses/$pkgname"
+
+    desktop-file-edit --set-key=Exec --set-value="heroic %U" flatpak/com.heroicgameslauncher.hgl.desktop
+    install -Dm644 flatpak/com.heroicgameslauncher.hgl.desktop -t "${pkgdir}/usr/share/applications"
+}

--- a/heroic-games-launcher/heroic.sh
+++ b/heroic-games-launcher/heroic.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec @ELECTRON@ /usr/lib/heroic-games-launcher/app.asar "$@"


### PR DESCRIPTION
This needs a few patches right now to work correctly. They should be included in the next version of Heroic though.

This is a copy-and-paste of the same script in my personal PKGBUILD repo here: <https://codeberg.org/CommandMC/PKGBUILDs/src/commit/23d4ac2823dacc17857febc8b5078306fd25ff5c/heroic-games-launcher/PKGBUILD>

Since I am one of the maintainers of Heroic, I hope this counts as enough of an official endorsement.

Two points:
1. I am not sure what to do with `heroic-games-launcher-bin` now. Do we just drop it, or keep it around in case this package causes some new issues?
2. Somewhat relating to (1), I was not sure whether I should've added `replaces=('heroic-games-launcher-bin')` to this package to automatically move users to it. In theory, it should just be a straight upgrade (using less disk space, keeping in line with Arch's Electron releases that may contain special changes).